### PR TITLE
Applicative

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "BSD (2 Clause)"
             :url "http://opensource.org/licenses/BSD-2-Clause"}
 
-  :dependencies [[cats "0.4.0"]]
+  :dependencies [[cats "0.5.0-SNAPSHOT"]]
   :deploy-repositories {"releases" :clojars
                         "snapshots" :clojars}
 
@@ -26,8 +26,8 @@
                                    :pretty-print true}}]}
 
   :jar-exclusions [#"\.swp|\.swo|user.clj"]
-  :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0-beta3"]
-                                  [org.clojure/clojurescript "0.0-3269"]
+  :profiles {:dev {:dependencies [[org.clojure/clojure "1.7.0"]
+                                  [org.clojure/clojurescript "0.0-3308"]
                                   [funcool/cljs-testrunners "0.1.0-SNAPSHOT"]]
                    :codeina {:sources ["src"]
                              :language :clojurescript

--- a/src/promesa/core.cljs
+++ b/src/promesa/core.cljs
@@ -33,6 +33,8 @@
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
 (declare then)
+(declare spread)
+(declare all)
 (declare promise)
 
 (def ^{:no-doc true}
@@ -41,6 +43,15 @@
     proto/Functor
     (fmap [mn f mv]
       (then mv f))
+
+    proto/Applicative
+    (pure [_ v]
+      (promise v))
+
+    (fapply [_ pf pv]
+      (spread (all [pf pv])
+              (fn [f v]
+                (f v))))
 
     proto/Monad
     (mreturn [_ v]

--- a/test/promesa/core_tests.cljs
+++ b/test/promesa/core_tests.cljs
@@ -89,6 +89,13 @@
                    (t/is (= v 3))
                    (done))))))
 
+(t/deftest promise-as-applicative
+  (t/async done
+    (let [rp (m/fapply (p/resolved inc) (p/promise 2))]
+      (p/then rp (fn [v]
+                   (t/is (= v 3))
+                   (done))))))
+
 (t/deftest promise-as-monad
   (t/async done
     (let [p1 (m/>>= (p/promise 2) (fn [v] (m/return (inc v))))]


### PR DESCRIPTION
It's a bit strange to have to use `resolve` instead of `promise` to create a promise containing a function but it probably is the most expected behavior. Maybe we should add a note mentioning it to the docs?