### PR TITLE
Support non-Function promise callbacks in cljs

### DIFF
--- a/src/promesa/core.cljc
+++ b/src/promesa/core.cljc
@@ -99,11 +99,11 @@
 
      p/IPromise
      (-map [it cb]
-       (.then it cb))
+       (.then it #(cb %)))
      (-bind [it cb]
-       (.then it cb))
+       (.then it #(cb %)))
      (-catch [it cb]
-       (.catch it cb))
+       (.catch it #(cb %)))
 
      p/IState
      (-resolved? [it]


### PR DESCRIPTION
Closes #9 

I used a multimethod for the `catch` test because I couldn't think of something simpler which is both applicable to an error and which doesn't compile to a Javascript `Function`.

I noticed that non Error objects can be passed to `reject` in Clojurescript, but not in Clojure - not sure whether you're interested in preserving that constraint across platforms, so I haven't created an issue.