### PR TITLE
Extend IPromiseFactory to cover boolean&string in cljs

### DIFF
--- a/src/promesa/core.cljc
+++ b/src/promesa/core.cljc
@@ -200,6 +200,10 @@
 
      boolean
      (-promise [v]
+       (.resolve js/Promise v))
+
+     string
+     (-promise [v]
        (.resolve js/Promise v))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/src/promesa/core.cljc
+++ b/src/promesa/core.cljc
@@ -196,6 +196,10 @@
 
      number
      (-promise [v]
+       (.resolve js/Promise v))
+
+     boolean
+     (-promise [v]
        (.resolve js/Promise v))))
 
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;

--- a/test/promesa/core_tests.cljc
+++ b/test/promesa/core_tests.cljc
@@ -33,6 +33,11 @@
     (t/is (p/done? p1))
     (t/is (= (p/extract p1) true))))
 
+(t/deftest promise-from-string-value
+  (let [p1 (p/promise "hello")]
+    (t/is (p/done? p1))
+    (t/is (= (p/extract p1) "hello"))))
+
 (t/deftest promise-from-factory
   (let [p1 (p/promise (fn [resolve _] (resolve 1)))]
     #?(:clj (deref p1))

--- a/test/promesa/core_tests.cljc
+++ b/test/promesa/core_tests.cljc
@@ -28,6 +28,11 @@
     (t/is (p/done? p1))
     (t/is (= (p/extract p1) 1))))
 
+(t/deftest promise-from-boolean-value
+  (let [p1 (p/promise true)]
+    (t/is (p/done? p1))
+    (t/is (= (p/extract p1) true))))
+
 (t/deftest promise-from-factory
   (let [p1 (p/promise (fn [resolve _] (resolve 1)))]
     #?(:clj (deref p1))


### PR DESCRIPTION
On the JVM, the Object protocol extension catches Boolean/String, but not in Javascript.

P.S. How do you feel about extending to nil, or that'd have surprising consequences?  The non-nil requirement can make some `alet` bodies a little awkward.