### PR TITLE
Use IWriter.-write in js/Promise's IPrintWithWriter impl

### DIFF
--- a/src/promesa/core.cljc
+++ b/src/promesa/core.cljc
@@ -552,4 +552,4 @@
    (extend-type Promise
      IPrintWithWriter
      (-pr-writer [p writer opts]
-       (.write writer (promise->str p)))))
+       (-write writer (promise->str p)))))

--- a/test/promesa/core_tests.cljc
+++ b/test/promesa/core_tests.cljc
@@ -23,6 +23,9 @@
 ;; Core Interface Tests
 ;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;
 
+(t/deftest print-promise
+  (t/is (string? (pr-str (p/promise nil)))))
+
 (t/deftest promise-from-value
   (let [p1 (p/promise 1)]
     (t/is (p/done? p1))


### PR DESCRIPTION
I upgraded to 1.1.0 and bumped into `TypeError: writer.write is not a function` in a cljs repl.  The test I added errors in master.

Thanks for all your work on the project.