### PR TITLE
Add Promise.noConflict to _bluebird/externs.js

### DIFF
--- a/assets/_bluebird/externs.js
+++ b/assets/_bluebird/externs.js
@@ -97,3 +97,9 @@ Promise.reject = function() {};
  * @return {Promise}
  */
 Promise.delay = function() {};
+
+/**
+ * @this {null}
+ * @return {Promise}
+ */
+Promise.noConflict = function() {};


### PR DESCRIPTION
This allows the tests to pass w/ `:optimizations` `:advanced`