### PR TITLE
In core/finally, ignore cb args & call supplied fn w/ no args

### DIFF
--- a/src/promesa/core.cljc
+++ b/src/promesa/core.cljc
@@ -172,8 +172,8 @@
   resolved or rejected."
   [p callback]
   #?(:clj (-> p
-              (then #(callback))
-              (catch #(callback)))
+              (then (fn [_] (callback)))
+              (catch (fn [_] (callback))))
      :cljs (.finally p callback)))
 
 (defn all


### PR DESCRIPTION
Fix for #32.  I tried testing this, but it looked like it might require CountDownLatch or similar within the test to ensure we give the finally function a fair chance to run in all cases.  I was going w/ something like:

```clojure
(t/deftest finally
  (let [p          (p/resolved 1)
        completed? (atom false)]
    (p/finally p
      (fn []
        (reset! completed? true)))
    #?(:cljs
       (t/async done
         (p/then p
           (fn [_]
             (t/is @completed?)
             (done))))
       :clj
       (do
         @p
         (t/is @completed?)))))
```

But it was only passing intermittently, and didn't seem like it was worth making the test much more complicated.  Happy to separately add tests for finally, though.