### PR TITLE
Allow renaming of await in alet macro

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject funcool/promesa "1.7.0"
+(defproject funcool/promesa "1.7.1-SNAPSHOT"
   :description "A promise library for ClojureScript"
   :url "https://github.com/funcool/promesa"
   :license {:name "BSD (2 Clause)"

--- a/test/promesa/issue_36.cljs
+++ b/test/promesa/issue_36.cljs
@@ -1,0 +1,19 @@
+(ns promesa.issue-36
+  "Test for https://github.com/funcool/promesa/issues/36."
+  (:require [cljs.test :as t]
+            [promesa.test-helpers :refer [future-ok]]
+            [promesa.core :as p
+             :refer [await]
+             :rename {await <!}
+             :refer-macros [alet]]))
+
+(t/deftest async-let-issue-36
+  (t/async done
+           (let [result (p/alet [a (<! (future-ok 50 1))
+                                 b 2
+                                 c 3
+                                 d (<! (future-ok 100 4))]
+                                (+ a b c d))]
+             (p/then result (fn [result]
+                              (t/is (= result 10))
+                              (done))))))

--- a/test/promesa/test_helpers.cljc
+++ b/test/promesa/test_helpers.cljc
@@ -1,0 +1,12 @@
+(ns promesa.test-helpers
+  (:require [promesa.core :as p]))
+
+(defn future-ok
+  [sleep value]
+  (p/promise (fn [resolve reject]
+               (p/schedule sleep #(resolve value)))))
+
+(defn future-fail
+  [sleep value]
+  (p/promise (fn [_ reject]
+               (p/schedule sleep #(reject value)))))


### PR DESCRIPTION
Fix for https://github.com/funcool/promesa/issues/36.

The following code will now be able to run:

```
(ns catfacts.scratch
  (:require [promesa.core :as p
             :refer [await]
             :rename {await <!}
             :refer-macros [alet]]))

(def nodegit (js/require "nodegit"))
(def repo (.-Repository nodegit))

(-> (alet [r (<! (.open repo ".."))
             commit (<! (.getBranchCommit r "master"))
             message (<! (.message commit))]
            (println message))
    (p/catch  (fn [err]
                (println "ERROR:" err))))
```