### PR TITLE
In clj, resolve promises returned by `then` callbacks

### DIFF
--- a/src/promesa/core.cljc
+++ b/src/promesa/core.cljc
@@ -127,11 +127,19 @@
   (pt/-bind p f))
 
 (defn then
-  "Same as `map` but with parameters inverted
+  "Similar to `map` but with parameters inverted
   for convenience and for familiarity with
-  javascript's promises `.then` operator."
+  javascript's promises `.then` operator.
+
+  Unlike Clojure's `map`, will resolve any promises
+  returned  by `f`."
   [p f]
-  (pt/-map p f))
+  #?(:cljs (pt/-map p f)
+     :clj  (pt/-bind p (fn promise-wrap [in]
+                         (let [out (f in)]
+                           (if (promise? out)
+                             out
+                             (promise out)))))))
 
 (defn chain
   "Like then but accepts multiple parameters."

--- a/test/promesa/core_tests.cljc
+++ b/test/promesa/core_tests.cljc
@@ -139,6 +139,17 @@
            p3 (p/then p2 inc)]
        (t/is (= @p3 4)))))
 
+(t/deftest then-promise
+  (let [p (-> (p/resolved 5)
+              (p/then (comp p/resolved inc))
+              (p/then (comp p/resolved inc)))]
+    #?(:clj (t/is (= @p 7))
+       :cljs
+       (t/async done
+         (p/then p (fn [v]
+                     (t/is (= v 7))
+                     (done)))))))
+
 (t/deftest chaining-using-map
   #?(:cljs
      (t/async done


### PR DESCRIPTION
Closes #35.

Note that I didn't touch bind, which I think is a candidate for removal, because it behaves identically to then in cljs, and the only difference in clj is that bind will throw an exception if the callback doesn't return a promise. 