### PR TITLE
Avoid compiler warnings caused by .finally/.catch

### DIFF
--- a/assets/_bluebird/externs.js
+++ b/assets/_bluebird/externs.js
@@ -324,3 +324,15 @@ Promise.fromCallback = function() {};
  * @return {Function}
  */
 Promise.fromNode = function() {};
+
+/**
+ * @this {Promise}
+ * @return {Promise}
+ */
+Promise.prototype.lastly = function() {};
+
+/**
+ * @this {Promise}
+ * @return {Promise}
+ */
+Promise.prototype.caught = function() {};

--- a/src/promesa/core.cljc
+++ b/src/promesa/core.cljc
@@ -182,7 +182,7 @@
   #?(:clj (-> p
               (then (fn [_] (callback)))
               (catch (fn [_] (callback))))
-     :cljs (.finally p callback)))
+     :cljs (.lastly p callback)))
 
 (defn all
   "Given an array of promises, return a promise

--- a/src/promesa/impl.cljc
+++ b/src/promesa/impl.cljc
@@ -56,7 +56,7 @@
      (-bind [it cb]
        (.then it #(cb %)))
      (-catch [it cb]
-       (.catch it #(cb %)))
+       (.caught it #(cb %)))
 
      pt/IState
      (-extract [it]


### PR DESCRIPTION
When using Promise with advanced compilation for ClojureScript, you'll get error messages like this:

    WARNING: /whatever/promesa/core.js:254: WARNING - Keywords and reserved words are not allowed as unquoted property names in older versions of JavaScript. If you are targeting newer versions of JavaScript, set the appropriate language_in option.
    return p.finally(callback);
             ^

```
WARNING: /whatever/promesa/impl/promise.js:41: WARNING - Keywords and reserved words are not allowed as unquoted property names in older versions of JavaScript. If you are targeting newer versions of JavaScript, set the appropriate language_in option.
return it__$1.catch(((function (it__$1){
              ^
```

This patch makes the messages go away by using the aliases `.lastly` and `.caught` provided by Bluebird for backwards compatibility with old JavaScript versions.

http://bluebirdjs.com/docs/api/finally.html
http://bluebirdjs.com/docs/api/catch.html