### PR TITLE
Convert promesa.core/all's result to a vector

### DIFF
--- a/src/promesa/core.cljc
+++ b/src/promesa/core.cljc
@@ -187,9 +187,23 @@
 (defn all
   "Given an array of promises, return a promise
   that is fulfilled  when all the items in the
-  array are fulfilled."
+  array are fulfilled.
+
+  Example:
+
+  (-> (all [(promise :first-promise)
+            (promise :second-promise)]
+      (then (fn [[first-result second-result]]))
+       (println (str first-result \", \" second-result)
+
+  Will print out
+  :first-promise, :second-promise.
+
+  If at least one of the promises is rejected, the resulting promise will be
+  rejected."
   [promises]
-  #?(:cljs (.all Promise (into-array promises))
+  #?(:cljs (-> (.all Promise (into-array promises))
+               (then vec))
      :clj (let [promises (clojure.core/map pt/-promise promises)]
             (then (->> (into-array CompletableFuture promises)
                        (CompletableFuture/allOf))


### PR DESCRIPTION
It is often useful to apply functions from clojure.core to
promesa.core/all's result e.g.

```
(-> (p/all bunch-of-promises)
    (p/then (fn [results]
             (conj results :foo)))
    (p/then something-else))
```

In the current cljs implementation, results is a javascript native
array. Which means the code above will fail. What I end up doing very
often is calling `vec` or `list` over `results`.

The intention of this PR is to convert the result of a `promesa.core/all` promise
to a clojure datastructure.

I also added more documentation.