### PR TITLE
Delay creating default executor to support GraalVM native compilation

### DIFF
--- a/src/promesa/async.clj
+++ b/src/promesa/async.clj
@@ -74,7 +74,7 @@
   {:no-doc true
    :internal true}
   [f]
-  (.execute impl/*executor* ^Runnable f))
+  (.execute (impl/get-executor) ^Runnable f))
 
 
 (defmacro async

--- a/src/promesa/impl.cljc
+++ b/src/promesa/impl.cljc
@@ -39,7 +39,14 @@
 ;; --- Global Constants
 
 #?(:clj
-   (def ^:dynamic *executor* (ForkJoinPool/commonPool)))
+   (def ^:dynamic *executor* (delay (ForkJoinPool/commonPool))))
+
+#?(:clj
+   (defn ^Executor get-executor
+     []
+     (if (delay? *executor*)
+       @*executor*
+       *executor*)))
 
 #?(:cljs
    (def ^:dynamic *default-promise* js/Promise))
@@ -80,7 +87,7 @@
                     (apply [_ v]
                       (clojure.lang.Var/resetThreadBindingFrame binds)
                       (cb v)))]
-         (.thenApplyAsync it ^Function func ^Executor *executor*)))
+         (.thenApplyAsync it ^Function func ^Executor (get-executor))))
 
      (-bind [it cb]
        (let [binds (clojure.lang.Var/getThreadBindingFrame)
@@ -88,7 +95,7 @@
                     (apply [_ v]
                       (clojure.lang.Var/resetThreadBindingFrame binds)
                       (cb v)))]
-         (.thenComposeAsync it ^Function func ^Executor *executor*)))
+         (.thenComposeAsync it ^Function func ^Executor (get-executor))))
 
      (-catch [it cb]
        (let [binds (clojure.lang.Var/getThreadBindingFrame)

--- a/test/promesa/core_tests.cljc
+++ b/test/promesa/core_tests.cljc
@@ -77,7 +77,7 @@
                       (done)))))
      :clj
      (let [p1 (p/promise (fn [resolve reject]
-                           (p/schedule 50 #(resolve 1))))]
+                           (p/schedule 500 #(resolve 1))))]
        (t/is (p/pending? p1))
        (t/is (= @p1 1)))))
 


### PR DESCRIPTION
This PR is to fix the error below when trying to compile promesa and/or other libraries that depend on it such as httpurr for GraalVM native image. Please let me know if this is a viable option, or if you'd like to work on alternative approaches.

A similar issue was resolved for `core.async` in [ASYNC-216](https://clojure.atlassian.net/browse/ASYNC-216) with the same approach and released on `0.4.490`.

```Detailed message:
Error: Detected the ForkJoinPool.commonPool() in the image heap. The common pool must be created at run time because the parallelism depends on the number of cores available at run time. Therefore the common pool used during image generation must not be reachable, e.g., via a static field that caches a copy of the common pool. The object was probably created by a class initializer and is reachable from a static field. By default, all class initialization is done during native image building.You can manually delay class initialization to image run time by using the option -H:ClassInitialization=<class-name>. Or you can write your own initialization methods and call them explicitly from your main entry point.
Trace: 	object clojure.lang.Var
	method promesa.impl$fn__2493.invokeStatic(Object, Object)
Call path from entry point to promesa.impl$fn__2493.invokeStatic(Object, Object):
	at promesa.impl$fn__2493.invokeStatic(impl.cljc:69)
	at promesa.impl$fn__2493.invoke(impl.cljc:69)
        ...
```