### PR TITLE
Fix typos in documentation

### DIFF
--- a/doc/content.adoc
+++ b/doc/content.adoc
@@ -13,9 +13,9 @@ Andrey Antukh, <niwi@niwi.nz>
 
 A promise library for Clojure and ClojureScript.
 
-On the JVM paltform _promesa_ is built on top of *completable futures*
-(requires jdk>=8). On JS engines it is built on top of the execution
-environment built-in Promise implementation.
+On the JVM platform, _promesa_ is built on top of *completable futures*
+(requires JDK >=8). On JS engines, it is built on top of the execution
+environment's built-in Promise implementation.
 
 
 === Install
@@ -105,6 +105,7 @@ Another option is using a factory function. If you are familiar with JavaScript,
 this is a similar approach.
 
 Example creating a promise instance using a factory.
+
 [source, clojure]
 ----
 @(p/create (fn [resolve reject] (resolve 1)))
@@ -132,7 +133,7 @@ Another way to create a promise is using the `do!` macro:
     (+ a b)))
 ----
 
-The `do!` macro works similarly to clojure's `do` block, so you can provide any
+The `do!` macro works similarly to Clojure's `do` block, so you can provide any
 expression, but only the last one will be returned. That expression can be a
 plain value or another promise.
 
@@ -198,16 +199,16 @@ purpose `then` function:
 ;; => 2
 ----
 
-As you can observe in the example, it handles functions that return plain values as
-well as functions that return promise instances (which will automatically be
-flattened).
+As you can observe in the example, `then` handles functions that return plain
+values as well as functions that return promise instances (which will
+automatically be flattened).
 
 NOTE: If you know that the chained function will always return plain values, you
-can use the `then'` more performant variant of this function.
+can use the more performant `then'` variant of this function.
 
 
-In the same line as the `then'` function, there is a `map`. It works identically to
-it, the unique difference is the order of arguments:
+The `map` function works similarly to the `then'` function, the difference is the
+order of arguments:
 
 [source, clojure]
 ----
@@ -235,8 +236,8 @@ there are the `chain` and `chain'` functions:
 NOTE: these are analogous to `then` and `then'` but accept multiple
 transformation functions.
 
-If you want to handle rejected and resolved callabacks in one unique callback,
-then you can use the `handler` chain function:
+If you want to handle rejected and resolved callbacks in one unique callback,
+then you can use the `handle` chain function:
 
 [source, clojure]
 ----
@@ -250,19 +251,20 @@ then you can use the `handler` chain function:
 ----
 
 And finally if you want to attach a (potentially side-effectful) callback to be
-always executed notwithstanding if the promise is rejected or resolved, there is a
+executed regardless of whether the promise is rejected or resolved, there is a
 `finally` function (very similar to try/finally):
 
 [source, clojure]
 ----
 (def result
   (-> (p/promise 1)
-      (p/handle (fn []
-                  (println "finally")))))
+      (p/finally (fn []
+                   (println "finally")))))
 
 @result
 ;; => 1
-;; => stdout: "finally"
+;; finally
+;; => nil
 ----
 
 
@@ -270,13 +272,14 @@ always executed notwithstanding if the promise is rejected or resolved, there is
 
 ==== `let`
 
-The _promesa_ library comes with convenient syntactic-sugar that allows you to
-create a composition that looks like synchronous code while using the clojure's
+The _promesa_ library comes with convenient syntactic sugar that allows you to
+create a composition that looks like synchronous code while using Clojure's
 familiar `let` syntax:
 
 [source, clojure]
 ----
-(require '[promesa.exec :as exec])
+(require '[promesa.core :as p]
+         '[promesa.exec :as exec])
 
 ;; A function that emulates asynchronos behavior.
 (defn sleep-promise
@@ -294,11 +297,11 @@ familiar `let` syntax:
 ;; => 85
 ----
 
-The `let` macro behaves identically to the `let` with the exception that it
-always return a promise. If an error occurs at any step, the entire composition
-will be short-circuited, returning exceptionally resolved promise.
+The `let` macro behaves identically to Clojure's `let` with the exception that
+it always returns a promise. If an error occurs at any step, the entire
+composition will be short-circuited, returning exceptionally resolved promise.
 
-Under the hood, the previous `let` macro evalutes to something like this:
+Under the hood, the `let` macro evalutes to something like this:
 
 [source, clojure]
 ----
@@ -333,11 +336,11 @@ executed when all parallel operations have successfully resolved.
 @(p/plet [a (p/delay 100 1)
           b (p/delay 200 2)
           c (p/delay 120 3)]
-   (+ na b c))
-;; => result: 6
+   (+ a b c))
+;; => 6
 ----
 
-The `plet` macro is just a syntactic sugar on top of `all`. The previous example
+The `plet` macro is just syntactic sugar on top of `all`. The previous example
 can be written using `all` in this manner:
 
 [source, clojure]
@@ -381,11 +384,11 @@ from that promise:
 === Error handling
 
 One of the advantages of using the promise abstraction is that it natively has a
-notion of errors, so you don't need reinvent it. If some computation inside the
+notion of errors, so you don't need to reinvent it. If some computation inside the
 composed promise chain/pipeline raises an exception, the pipeline short-circuits
 and propogates the exception to the last promise in the chain.
 
-Let see an example:
+Let's see an example:
 
 [source, clojure]
 ----
@@ -397,9 +400,9 @@ Let see an example:
 The `catch` function adds a new handler to the promise chain that will be called
 when any of the previous promises in the chain are rejected or an exception is
 raised. The `catch` function also returns a promise that will be resolved or
-rejected depending on that will happen inside the catch handler.
+rejected depending on what happens inside the catch handler.
 
-If you prefer `map`-like parameters order, the `err` function (and `error`
+If you prefer `map`-like parameter ordering, the `err` function (and `error`
 alias) works in same way as `catch` but has parameters ordered like `map`:
 
 [source, clojure]
@@ -409,17 +412,14 @@ alias) works in same way as `catch` but has parameters ordered like `map`:
                 (.log js/console error))))
 ----
 
-[NOTE]
-====
-On the JVM platform the reject value must be an instance of `Throwable`, but on
-the JavaScript platform the reject value can be any value.
-====
+NOTE: On the JVM platform the reject value must be an instance of `Throwable`,
+but on the JavaScript platform the reject value can be any value.
 
 
-=== Delays and timeouts.
+=== Delays and timeouts
 
-JavaScript, due its single-threaded nature, does not allow you to block or
-sleep. But, with promises you can emulate that functionality using `delay` like
+JavaScript, due to its single-threaded nature, does not allow you to block or
+sleep. But with promises you can emulate that functionality using `delay` like
 so:
 
 [source, clojure]
@@ -451,7 +451,7 @@ handler.
 === Scheduling Tasks
 
 In addition to the promise abstraction, this library also comes with a
-lightweight abstraction for scheduling task to be executed at some time in
+lightweight abstraction for scheduling tasks to be executed at some time in
 future:
 
 .Example using the `schedule` function.
@@ -463,7 +463,7 @@ future:
 ----
 
 This example shows you how you can schedule a function call to be executed 1
-second in the future. It works the same way for both plaforms (clj and cljs).
+second in the future. It works the same way for both Clojure and ClojureScript.
 
 The tasks can be cancelled using its return value:
 
@@ -478,9 +478,9 @@ The tasks can be cancelled using its return value:
 
 === Execution model
 
-NOTE: This section is mainly affects the **JVM**.
+NOTE: This section mainly affects the **JVM**.
 
-Lets take this example as a context:
+Lets consider this example:
 
 [source, clojure]
 ----
@@ -490,8 +490,8 @@ Lets take this example as a context:
 ;; => 3
 ----
 
-This will create a promise that will resolve to `1` in 100ms (in a separated
-thread); then the first `inc` will be executed (in the same thread) and then
+This will create a promise that will resolve to `1` in 100ms (in a separate
+thread), then the first `inc` will be executed (in the same thread) and then
 another `inc` is executed (in the same thread). In total only one thread is
 involved.
 
@@ -517,7 +517,7 @@ user-defined executor to control where the chained callbacks are executed:
 ;; => 3
 ----
 
-This will schedule a separated task for each chained callback, making the whole
+This will schedule a separate task for each chained callback, making the whole
 system more responsive because you are no longer executing big blocking
 functions; instead you are executing many small tasks.
 
@@ -527,14 +527,14 @@ optimized for lots of small tasks.
 
 === Performance overhead
 
-The **promesa** is a lightweight abstraction built on top of native facilities
-(`CompletableFuture` in the jvm and `js/Promise` on cljs).
+_promesa_ is a lightweight abstraction built on top of native
+facilities (`CompletableFuture` in the JVM and `js/Promise` in JavaScript).
 
-Internaly we have heavy use of protocols in order to expose a polimorphic and
-user friendly api, and this have a little overhead on top of raw usage of
+Internally we make heavy use of protocols in order to expose a polymorphic and
+user-friendly API, and this has little overhead on top of raw usage of
 `CompletableFuture` or `Promise`. This is the latest micro benchmark
-(2019-09-17) that shows the real overhead of this library in contrat to use
-plain native abstractions:
+(2019-09-17) that shows the real overhead of this library in contrast to the
+use of native abstractions:
 
 [source, clojure]
 ----
@@ -595,7 +595,7 @@ The benchmarked functions are:
 === Contributing
 
 Unlike Clojure and other Clojure contrib libs, this project does not have many restrictions for
-contributions. Just open a issue or pull request.
+contributions. Just open an issue or pull request.
 
 
 === Get the Code
@@ -630,7 +630,7 @@ And for JS platform:
 node out/tests.js
 ----
 
-You will need to have nodejs installed on your system.
+You will need to have Node.js installed on your system.
 
 
 === License


### PR DESCRIPTION
This PR fixes spelling, grammatical and syntax mistakes in the documentation. PR #76 fixed a number of errors but there were several that remained outstanding.