### PR TITLE
Properly handle nil/Object instances on `then`

### DIFF
--- a/src/promesa/impl.cljc
+++ b/src/promesa/impl.cljc
@@ -245,6 +245,9 @@
      (-bind
        ([it f] (pt/-bind (pt/-promise it) f))
        ([it f e] (pt/-bind (pt/-promise it) f e)))
+     (-then
+       ([it f] (pt/-then (pt/-promise it) f))
+       ([it f e] (pt/-then (pt/-promise it) f e)))
      (-handle
        ([it f] (pt/-handle (pt/-promise it) f))
        ([it f e] (pt/-handle (pt/-promise it) f e)))
@@ -265,6 +268,9 @@
      (-bind
        ([it f] (pt/-bind (pt/-promise it) f))
        ([it f e] (pt/-bind (pt/-promise it) f e)))
+     (-then
+       ([it f] (pt/-then (pt/-promise it) f))
+       ([it f e] (pt/-then (pt/-promise it) f e)))
      (-mapErr
        ([it f] (pt/-mapErr (pt/-promise it) f))
        ([it f e] (pt/-mapErr (pt/-promise it) f e)))


### PR DESCRIPTION
Version `6.0.0` fixed a CLJS bug where non-promise objects couldn't have callbacks chained to them using `then`. This fix _wasn't_ applied to non-`CompletableFuture` objects in JVM-based Clojure, which results in the library having different semantics of `then` depending on the runtime, which can be confusing to library users.

Example of the bug in Clojure 1.10.1:
```Clojure
(in-ns 'promesa.core)
=> #object[clojure.lang.Namespace 0x4b8e160c "promesa.core"]

Loading src/promesa/core.cljc... done

(def v "hello")
=> #'promesa.core/v

(then v println)
Execution error (IllegalArgumentException) at promesa.protocols/eval1521$fn$G (protocols.cljc:28).
No implementation of method: :-then of protocol: #'promesa.protocols/IPromise found for class: java.lang.String
```

This MR fixes this discrepancy by allowing to chain callbacks to `java.lang.Object` and `nil`.