### PR TITLE
Fix scheduled-pool constructor

### DIFF
--- a/src/promesa/exec.cljc
+++ b/src/promesa/exec.cljc
@@ -140,9 +140,9 @@
 
 #?(:clj
    (defn scheduled-pool
-     "A scheduled thread pool constructo."
+     "A scheduled thread pool constructor."
      ([] (Executors/newScheduledThreadPool (int 0)))
-     ([n] (Executors/newScheduledThreadPool (int 0)))
+     ([n] (Executors/newScheduledThreadPool (int n)))
      ([n opts]
       (let [factory (resolve-thread-factory opts)]
         (Executors/newScheduledThreadPool (int n) factory)))))


### PR DESCRIPTION
I just came across this issue where the constructor parameter is not correctly handled (at least my assumption is that the intended behavior is the proposed one 🙂 )