### PR TITLE
Remove extra parens in timeout-test-2

### DIFF
--- a/test/promesa/tests/core_test.cljc
+++ b/test/promesa/tests/core_test.cljc
@@ -303,13 +303,13 @@
        (let [prm (-> (p/delay 200 :value)
                      (p/timeout 300))]
          (p/then prm (fn [v]
-                        (t/is (= (v :value)))
+                        (t/is (= v :value))
                         (done)))))
      :clj
      (let [prm (-> (p/delay 200 :value)
                    (p/timeout 500))]
        @(p/then prm (fn [v]
-                     (t/is (= (v :value))))))))
+                     (t/is (= v :value)))))))
 
 (t/deftest chaining-using-chain
   #?(:cljs


### PR DESCRIPTION
Fix error found via clj-kondo:

    Single operand use of cljs.core/= is always true
