### PR TITLE
Add support for async as-> thread macro.

### DIFF
--- a/src/promesa/core.cljc
+++ b/src/promesa/core.cljc
@@ -26,7 +26,7 @@
   (:refer-clojure :exclude [delay spread promise
                             await map mapcat run!
                             future let loop recur
-                            -> ->>])
+                            -> ->> as->])
   (:require
    [promesa.protocols :as pt]
    [clojure.core :as c]
@@ -499,3 +499,14 @@
                                            (list arg))]
                         `(fn [p#] (~f ~@args p#)))) forms)]
     `(chain (promise ~x) ~@fns)))
+
+(defmacro as->
+  "Like clojure.core/as->, but it will handle promises in values
+   and make sure the next form gets the value realized instead of
+   the promise."
+  [expr name & forms]
+  `(let [~name ~expr
+         ~@(interleave (repeat name) (butlast forms))]
+     ~(if (empty? forms)
+        name
+        (last forms))))

--- a/test/promesa/tests/core_test.cljc
+++ b/test/promesa/tests/core_test.cljc
@@ -449,3 +449,12 @@
         test #(p/then p1 (fn [res] (t/is (= res [2 3 4]))))]
     #?(:cljs (t/async done (p/do! (test) (done)))
        :clj @(test))))
+
+(t/deftest thread-as-last-macro
+  (let [p1   (p/as-> (p/future [1 2 3]) <>
+               (reduce + 8 <>)
+               (/ <> 2)
+               (future-inc <>))
+        test #(p/then p1 (fn [res] (t/is (= res 8))))]
+    #?(:cljs (t/async done (p/do! (test) (done)))
+       :clj @(test))))


### PR DESCRIPTION
To complete the threading functionality from `clojure.core`, this adds support for an async `as->` variant.