### PR TITLE
Added with-redefs macro and tests

### DIFF
--- a/test/promesa/tests/core_test.cljc
+++ b/test/promesa/tests/core_test.cljc
@@ -458,3 +458,13 @@
         test #(p/then p1 (fn [res] (t/is (= res 8))))]
     #?(:cljs (t/async done (p/do! (test) (done)))
        :clj @(test))))
+
+(t/deftest with-redefs-macro
+  (let [a-fn (fn [] (p/resolved "original"))
+        a-var :original
+        p1   (p/with-redefs [a-fn (fn [] (p/resolved "mocked"))
+                             a-var :mocked]
+               (p/then (a-fn) #(vector % a-var)))
+        test #(p/then p1 (fn [res] (t/is (= res ["mocked" :mocked]))))]
+    #?(:cljs (t/async done (p/do! (test) (done)))
+       :clj @(test))))


### PR DESCRIPTION
Works like `with-redefs` but accepts promises in the body and waits until they
finish before restoring their original var values