### PR TITLE
Add testing instructions to readme and update ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,6 +27,6 @@ before_script:
 
 script:
   - clojure -Adev -m promesa.tests.main
-  - clojure -Adev tools.clj build:tests
+  - clojure -Adev tools.clj build
   - node out/tests.js
 

--- a/README.md
+++ b/README.md
@@ -27,3 +27,20 @@ way as you will do it in JS with async/await).
 See the complete [documentation](https://funcool.github.io/promesa/latest/) for
 more detailed information.
 
+
+# Contributing
+
+## Testing
+
+Run the Clojure (.clj) tests:
+
+``` shell
+clojure -Adev -m promesa.tests.main
+```
+
+Run the ClojureScript (.cljs) tests:
+
+``` shell
+clj -Adev tools.clj build
+node out/tests.js
+```


### PR DESCRIPTION
- Updates readme to surface how to run tests
- Updates .travis.yml to use `build` instead of `build:tests` which does not
  seem to exist and was not referenced in tools.clj