### PR TITLE
CSP: always call transducer completion arity

### DIFF
--- a/src/promesa/exec/csp/channel.cljc
+++ b/src/promesa/exec/csp/channel.cljc
@@ -330,8 +330,9 @@
     (when (compare-and-set! closed false true)
       (try
         (pt/-lock! this)
-        (when (and buf (zero? (mlist/size @puts)))
-          (add-fn buf))
+
+        ;; flush any transducer state
+        (some-> buf add-fn)
 
         (loop [items (seq @takes)]
           (when-let [taker (first items)]

--- a/test/promesa/tests/exec_csp_test.cljc
+++ b/test/promesa/tests/exec_csp_test.cljc
@@ -54,8 +54,19 @@
     (sp/put ch 2) ; buffer is full - queued, then dropped by close!
     (sp/close! ch)
 
-    (t/is (= [1] (sp/take! ch)))
-    (t/is (= [2] (sp/take! ch)))))
+    #?(:clj
+       (do
+         (t/is (= [1] (sp/take! ch)))
+         (t/is (= [2] (sp/take! ch))))
+
+       :cljs
+       (t/async done
+          (p/let [v1 (sp/take ch)
+                  v2 (sp/take ch)]
+
+            (t/is (= [1] v1))
+            (t/is (= [2] v2))
+            (done))))))
 
 (t/deftest non-blocking-ops-buffered-chan
   (let [ch (sp/chan 3)]

--- a/test/promesa/tests/exec_csp_test.cljc
+++ b/test/promesa/tests/exec_csp_test.cljc
@@ -47,6 +47,16 @@
     (t/is (= 2 (sp/poll! ch)))
     (t/is (= nil (sp/poll! ch)))))
 
+(t/deftest chan-with-stateful-transducer
+  (let [ch (sp/chan 1 (partition-by identity))]
+    (sp/put ch 1) ; starts as transducer state, fills buffer when 2 arrives
+    (sp/put ch 2) ; closes 1 partition, added to transducer state, flushed by close!
+    (sp/put ch 2) ; buffer is full - queued, then dropped by close!
+    (sp/close! ch)
+
+    (t/is (= [1] (sp/take! ch)))
+    (t/is (= [2] (sp/take! ch)))))
+
 (t/deftest non-blocking-ops-buffered-chan
   (let [ch (sp/chan 3)]
     (t/is (true? (sp/offer! ch :a)))


### PR DESCRIPTION
when a channel is `close!`d any transducer state should always be flushed by calling the completion arity

this PR ensures that happens