### PR TITLE
Avoid eval for GraalVM

### DIFF
--- a/src/promesa/exec.cljc
+++ b/src/promesa/exec.cljc
@@ -125,7 +125,7 @@
     :no-doc true}
   default-vthread-executor
   #?(:clj  (compile-if-virtual
-            (delay (java.util.concurrent.Executors/newThreadPerTaskExecutor
+            (delay (java.util.concurrent.Executors/newVirtualThreadPerTaskExecutor
                     ^ThreadFactory (promesa.exec/thread-factory)))
             default-cached-executor)
      :cljs default-executor))

--- a/src/promesa/exec.cljc
+++ b/src/promesa/exec.cljc
@@ -58,18 +58,24 @@
 (def ^:dynamic *default-scheduler* nil)
 (def ^:dynamic *default-executor* nil)
 
+(def virtual-threads-available?
+  "Var that indicates the availability of virtual threads."
+  #?(:clj (if (and (pu/has-method? Thread "ofVirtual")
+                   ;; the following should succeed with the `--enable-preview` java argument:
+                   ;; eval happens on top level = compile time, which is ok for GraalVM
+                   (try (eval '(Thread/ofVirtual))
+                        (catch Exception _ false)))
+            true
+            false)
+     :cljs false))
+
 #?(:clj
    (do
      (defmacro compile-if-virtual [then else]
-       (if (pu/has-method? Thread "ofVirtual")
+       (if virtual-threads-available?
          then else))
      (defmacro compile-when-virtual [body]
        `(compile-if-virtual ~body nil))))
-
-(def virtual-threads-available?
-  "Var that indicates the availability of virtual threads."
-  #?(:clj (compile-if-virtual true false)
-     :cljs false))
 
 ;; DEPRECATED
 (def ^{:deprecated true

--- a/src/promesa/exec.cljc
+++ b/src/promesa/exec.cljc
@@ -114,20 +114,20 @@
   ^{:doc "A global, thread per task executor service."
     :no-doc true}
   default-thread-executor
-  #?(:clj (or (compile-when-virtual
-               (delay (java.util.concurrent.Executors/newThreadPerTaskExecutor
-                       ^ThreadFactory (promesa.exec/thread-factory))))
-              default-cached-executor)
+  #?(:clj (compile-if-virtual
+           (delay (java.util.concurrent.Executors/newThreadPerTaskExecutor
+                   ^ThreadFactory (promesa.exec/thread-factory)))
+           default-cached-executor)
      :cljs default-executor))
 
 (defonce
   ^{:doc "A global, virtual thread per task executor service."
     :no-doc true}
   default-vthread-executor
-  #?(:clj  (or (compile-when-virtual
-                (delay (java.util.concurrent.Executors/newThreadPerTaskExecutor
-                        ^ThreadFactory (promesa.exec/thread-factory))))
-               default-cached-executor)
+  #?(:clj  (compile-if-virtual
+            (delay (java.util.concurrent.Executors/newThreadPerTaskExecutor
+                    ^ThreadFactory (promesa.exec/thread-factory)))
+            default-cached-executor)
      :cljs default-executor))
 
 (defn executor?

--- a/src/promesa/exec.cljc
+++ b/src/promesa/exec.cljc
@@ -125,8 +125,7 @@
     :no-doc true}
   default-vthread-executor
   #?(:clj  (compile-if-virtual
-            (delay (java.util.concurrent.Executors/newVirtualThreadPerTaskExecutor
-                    ^ThreadFactory (promesa.exec/thread-factory)))
+            (delay (java.util.concurrent.Executors/newVirtualThreadPerTaskExecutor))
             default-cached-executor)
      :cljs default-executor))
 


### PR DESCRIPTION
Promesa doesn't work on GraalVM due to runtime (non-top-level) usage of `eval`.
This PR avoids doing that and decides at compile time which branch should be taken.