### PR TITLE
add missing imports for classes used in type hints

### DIFF
--- a/src/promesa/exec/bulkhead.clj
+++ b/src/promesa/exec/bulkhead.clj
@@ -20,7 +20,8 @@
    java.util.concurrent.Executor
    java.util.concurrent.LinkedBlockingQueue
    java.util.concurrent.Semaphore
-   java.util.concurrent.atomic.AtomicLong))
+   java.util.concurrent.atomic.AtomicLong
+   java.util.function.Supplier))
 
 (set! *warn-on-reflection* true)
 ;; (set! *unchecked-math* :warn-on-boxed)

--- a/src/promesa/impl.cljc
+++ b/src/promesa/impl.cljc
@@ -25,6 +25,8 @@
       java.util.concurrent.Future
       java.util.concurrent.TimeUnit
       java.util.concurrent.TimeoutException
+      java.util.function.BiConsumer
+      java.util.function.BiFunction
       java.util.function.Function
       java.util.function.Supplier)))
 


### PR DESCRIPTION
There are several unqualified type hints in the code for classes that are not imported. These type hints are thus not resolvable and not being used. I don't think they actually are needed in the first place, but this PR adds the missing imports.