### PR TITLE
Faster `promesa.exec/wrap-bindings`

### DIFF
--- a/src/promesa/exec/csp.cljc
+++ b/src/promesa/exec/csp.cljc
@@ -67,7 +67,7 @@
   promise instance, has the same semantics as `go` macro."
   [& body]
   `(let [c# (chan :buf 1)
-         f# (px/wrap-bindings (fn [] ~@body))]
+         f# (px/wrap-bindings (^{:once true} fn* [] ~@body))]
      (->> (p/thread-call *executor* f#)
           (p/fnly (fn [v# e#]
                     (if e#
@@ -80,7 +80,7 @@
   a promise instance."
   [& body]
   `(let [c# (chan :buf 1)
-         f# (px/wrap-bindings (fn [] ~@body))]
+         f# (px/wrap-bindings (^{:once true} fn* [] ~@body))]
      (->> (p/thread-call :thread f#)
           (p/fnly (fn [v# e#]
                     (if e#


### PR DESCRIPTION
83x faster than current implementation, per benchmarks:
```Clojure
(run-benchmark ; run on a single pinned core for clean test purposes
  (fn []
    (testing "`promesa.exec.csp` implementation"
      ;; 4.956172 µs — this is due to `promesa.exec/wrap-bindings`'s way of forwarding
      ;; bindings, which is 83x slower than `clojure.core/binding-conveyor-fn`
      (criterium/bench
        (csp/go))
    (testing "Bare implementation"
      ;; 59.033042 ns
      (criterium/bench
        (-> (Thread/ofVirtual)
            (.unstarted (fn []))
            (.start))))
    (testing "With `clojure.core/binding-conveyor-fn` bindings forwarding"
      ;; 58.851215 ns
      (criterium/bench
        (-> (Thread/ofVirtual)
            (.unstarted (binding-conveyor-fn (^{:once true} fn* [])))
            (.start))))))
```