### PR TITLE
Fix syntax for `^:once` compiler hint

### DIFF
--- a/src/promesa/core.cljc
+++ b/src/promesa/core.cljc
@@ -655,21 +655,21 @@
   "Analogous to `clojure.core.async/thread` that returns a promise instance
   instead of the `Future`."
   [& body]
-  `(thread-call (^:once fn [] ~@body)))
+  `(thread-call (^:once fn* [] ~@body)))
 
 (defmacro vthread
   "Analogous to `clojure.core.async/thread` that returns a promise instance
   instead of the `Future`. Useful for executing synchronous code in a
   separate thread (also works in cljs)."
   [& body]
-  `(vthread-call (^:once fn [] ~@body)))
+  `(vthread-call (^:once fn* [] ~@body)))
 
 (defmacro future
   "Analogous macro to `clojure.core/future` that returns promise
   instance instead of the `Future`. Exposed just for convenience and
   works as an alias to `thread`."
   [& body]
-  `(thread-call :default (^once fn [] ~@body)))
+  `(thread-call :default (^:once fn* [] ~@body)))
 
 (defrecord Recur [bindings])
 


### PR DESCRIPTION
This commit fixes a couple of syntax issues:
- The metadata shorthand is the keyword `:once`
- `^:once` only has effect on `fn*`, it does nothing on `fn`

For comparison with `core.async`, see https://github.com/clojure/core.async/blob/8cc877fb59c00b729bcd3c05753c3782a77f9b01/src/main/clojure/clojure/core/async.clj#L516-L529

Further background: https://ask.clojure.org/index.php/13050/what-does-once-meta-applied-for-anon-function-mean